### PR TITLE
Can use router arguments to configure views

### DIFF
--- a/app/src/controller/PageController.php
+++ b/app/src/controller/PageController.php
@@ -30,7 +30,15 @@ class PageController
 
     public function load($args)
     {
-        if ($view = $args['view']) {
+        if (isset($args['view'])) {
+            // Configure view in session
+            if (isset($args['filter'])) {
+                $exploreFilter = $args['filter'];
+                $session = new SessionController();
+                $session->setExploreFilter($exploreFilter);
+            }
+            // Render view
+            $view = $args['view'];
             if ($args['auth'] === true) {
                 $this->viewCtrl->renderView($this->redirectUnauthorized($view), true);
             } else {

--- a/app/src/controller/SessionController.php
+++ b/app/src/controller/SessionController.php
@@ -51,4 +51,60 @@ class SessionController
             return null;
         }
     }
+
+    /**
+     * View configurable properties
+     * 
+     * Use the following methods to store parameters from the route query
+     * Views will depend on these values when rendered 
+     */
+
+    /**
+     * Set - Get selected post ID
+     * 
+     * Use to fetch a single post in selected post view
+     */
+    public function setSelectedPostId($postId) {
+        $_SESSION['selected'] = $postId;
+    }
+    public function getSelectedPostId() {
+        return $_SESSION['selected'] ?? null;
+    }
+
+    /**
+     * Set - Get explore filter
+     * 
+     * Use to fetch a specidic collection posts in explore view
+     */
+    public function setExploreFilter($filter) {
+        $_SESSION['filter'] = $filter;
+    }
+    public function getExploreFilter() {
+        return $_SESSION['filter'] ?? null;
+    }
+
+    /**
+     * Set - Get explore search key
+     * 
+     * Use to fetch posts containing the key in explore view
+     */
+    public function setExploreSearchKey($key) {
+        $_SESSION['searchKey'] = $key;
+    }
+    public function getExploreSearchKey() {
+        return $_SESSION['searchKey'] ?? null;
+    }
+
+    /**
+     * Set - Get explore search tag
+     * 
+     * Use to fetch a collection of tagged posts in explore view
+     */
+    public function setExploreSearchTag($tag) {
+        $_SESSION['searchTag'] = $tag;
+    }
+    public function getExploreSearchTag() {
+        return $_SESSION['searchTag'] ?? null;
+    }
+
 }

--- a/app/src/model/DAL/PostModel.php
+++ b/app/src/model/DAL/PostModel.php
@@ -104,7 +104,7 @@ class PostModel extends CoreModel
 					$row->CreatedAt,
 					$row->UserId,
 					$row->Username,
-					$row->LatestComment,
+					$row->LatestCommentId,
 					$row->ChildPostId,
 					$row->StatusId
 				);

--- a/app/src/view/auth/Explore.php
+++ b/app/src/view/auth/Explore.php
@@ -1,26 +1,36 @@
 <?php
 
 /**
- * Fetch all posts
+ * Setup controllers used in view
  */
+$sessionController = new SessionController();
 $postController = new PostController();
-$posts = $postController->fetchAll();
-
-/**
- * Media controller
- */
 $mediaController = new MediaController();
+$tagsController = new TagsController();
 
 /**
- * Tags controller
+ * Fetch posts
  */
-$tagsController = new TagsController();
+$filter = $sessionController->getExploreFilter();
+switch ($filter) {
+    case 'trending':
+        console_log('trending');
+        $posts = $postController->fetchAll();
+    break;
+    default:
+        console_log('all');
+        $posts = $postController->fetchAll();
+    break;
+}
+
+/**
+ * Fetch tags
+ */
 $tags = $tagsController->fetchAll();
 $tagTemplates = array();
 foreach ($tags as $tag) {
     $tagTemplates[] = $tag->getTagTemplate();
 }
-
 
 ?>
 


### PR DESCRIPTION
I would call it a workaround, but sessions are now used to store properties of views where we need to display a specific collection or a single post by filters or IDs.

Session properties should be set via the PageController by looking through the passed arguments from the router.
Session properties should be access in the views via a SessionController instance and its get methods.